### PR TITLE
#14 - 마켓 생성 요청에 로그인 기능 연동

### DIFF
--- a/src/main/java/com/flab/modu/market/controller/MarketController.java
+++ b/src/main/java/com/flab/modu/market/controller/MarketController.java
@@ -2,11 +2,14 @@ package com.flab.modu.market.controller;
 
 import com.flab.modu.market.domain.Market;
 import com.flab.modu.market.service.MarketService;
+import com.flab.modu.users.domain.common.UserConstant;
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 @RequiredArgsConstructor
 @RestController
@@ -16,9 +19,8 @@ public class MarketController {
 
     @PostMapping("/markets")
     public MarketDto.CreateResponse createMarket(
-        @RequestBody @Valid MarketDto.CreateRequest createRequest) {
-        //TODO seller_id는 현재 파라메터로 받게 되어있으나, 사용자 인증 부분이 개발이 완료되면, 세션정보에서 가져오도록 수정이 필요하다.
-
-        return marketService.createMarket(createRequest);
+        @RequestBody @Valid MarketDto.CreateRequest createRequest,
+        @SessionAttribute(value = UserConstant.EMAIL) String sellerId) {
+        return marketService.createMarket(createRequest, sellerId);
     }
 }

--- a/src/main/java/com/flab/modu/market/controller/MarketDto.java
+++ b/src/main/java/com/flab/modu/market/controller/MarketDto.java
@@ -16,9 +16,6 @@ public class MarketDto {
     @Getter
     @NoArgsConstructor
     public static class CreateRequest {
-
-        private String sellerId;
-
         @NotBlank(message = "마켓명을 입력해주세요.")
         @Length(min = 1, max = 200, message = "마켓명은 1자 이상 200자 이하로 입력해주세요.")
         private String name;
@@ -29,13 +26,12 @@ public class MarketDto {
         private String url;
 
         @Builder
-        public CreateRequest(String sellerId, String name, String url) {
-            this.sellerId = sellerId;
+        public CreateRequest(String name, String url) {
             this.name = name;
             this.url = url;
         }
 
-        public Market toEntity() {
+        public Market toEntity(String sellerId) {
             return Market.builder()
                 .sellerId(sellerId)
                 .name(name)

--- a/src/main/java/com/flab/modu/market/service/MarketService.java
+++ b/src/main/java/com/flab/modu/market/service/MarketService.java
@@ -13,12 +13,13 @@ public class MarketService {
 
     private final MarketRepository marketRepository;
 
-    public MarketDto.CreateResponse createMarket(MarketDto.CreateRequest createMarketRequest) {
+    public MarketDto.CreateResponse createMarket(MarketDto.CreateRequest createMarketRequest,
+        String sellerId) {
         if (checkUrlDuplicate(createMarketRequest.getUrl())) {
             throw new DuplicatedUrlException();
         }
 
-        Market savedMarket = marketRepository.save(createMarketRequest.toEntity());
+        Market savedMarket = marketRepository.save(createMarketRequest.toEntity(sellerId));
         return MarketDto.CreateResponse.builder().market(savedMarket).build();
     }
 

--- a/src/test/java/com/flab/modu/market/controller/MarketControllerTest.java
+++ b/src/test/java/com/flab/modu/market/controller/MarketControllerTest.java
@@ -16,13 +16,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.modu.market.controller.MarketDto.CreateResponse;
-import com.flab.modu.market.domain.Market;
-import com.flab.modu.market.domain.MarketStatus;
 import com.flab.modu.market.service.MarketService;
+import com.flab.modu.users.domain.common.UserConstant;
+import com.flab.modu.users.service.LoginService;
 import java.time.LocalDateTime;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,37 +35,58 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("Market Controller 테스트")
-@ExtendWith(SpringExtension.class)
 @AutoConfigureRestDocs
+@ExtendWith({SpringExtension.class})
 @WebMvcTest(MarketController.class)
 class MarketControllerTest {
-
-    @MockBean
-    private MarketService marketService;
 
     @Autowired
     private MockMvc mockMvc;
 
+    private MockHttpSession session;
+
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockBean
+    private MarketService marketService;
+
+    @MockBean
+    private LoginService loginService;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        String loginEmail = "user@test.com";
+        session = new MockHttpSession();
+        session.setAttribute(UserConstant.EMAIL, loginEmail);
+    }
+
+    @AfterEach
+    public void clean() {
+        session.clearAttributes();
+    }
 
     @Test
     @DisplayName("마켓 생성에 성공한다.")
     public void givenValidData_whenCreatingMarket_then200OK() throws Exception {
         //given
-        MarketDto.CreateRequest createRequest = createMarketCreateRequest("sellerId","MarketUrl","Market Name");
+        MarketDto.CreateRequest createRequest = createMarketCreateRequest("MarketUrl",
+            "Market Name");
         MarketDto.CreateResponse createResponse = createMarketCreateResponse(createRequest);
-        given(marketService.createMarket(any(MarketDto.CreateRequest.class))).willReturn(
+        given(marketService.createMarket(any(MarketDto.CreateRequest.class),
+            any(String.class))).willReturn(
             createResponse);
 
         //when
         ResultActions result = mockMvc.perform(post("/markets")
+            .session(session)
             .content(objectMapper.writeValueAsString(createRequest))
             .contentType(MediaType.APPLICATION_JSON)
         );
@@ -74,13 +97,14 @@ class MarketControllerTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.name").value(CoreMatchers.equalTo(createRequest.getName())))
             .andExpect(jsonPath("$.url").value(CoreMatchers.equalTo(createRequest.getUrl())))
-            .andExpect(jsonPath("$.sellerId").value(CoreMatchers.equalTo(createRequest.getSellerId())));
-        then(marketService).should().createMarket(refEq(createRequest));
+            .andExpect(jsonPath("$.sellerId").value(
+                CoreMatchers.equalTo((String) session.getAttribute(UserConstant.EMAIL))));
+        then(marketService).should().createMarket(refEq(createRequest),
+            refEq((String) session.getAttribute(UserConstant.EMAIL)));
 
         //document
         result.andDo(document("create-market",
             requestFields(
-                fieldWithPath("sellerId").type(JsonFieldType.STRING).description("판매자아이디"),
                 fieldWithPath("name").type(JsonFieldType.STRING).description("마켓명"),
                 fieldWithPath("url").type(JsonFieldType.STRING).description("마켓주소")
             ),
@@ -107,13 +131,15 @@ class MarketControllerTest {
         Assertions.assertThat(marketName.length()).isEqualTo(200);
         Assertions.assertThat(url.length()).isEqualTo(100);
 
-        MarketDto.CreateRequest createRequest = createMarketCreateRequest(sellerId, url, marketName);
+        MarketDto.CreateRequest createRequest = createMarketCreateRequest(url, marketName);
         MarketDto.CreateResponse createResponse = createMarketCreateResponse(createRequest);
-        given(marketService.createMarket(any(MarketDto.CreateRequest.class))).willReturn(
+        given(marketService.createMarket(any(MarketDto.CreateRequest.class),
+            any(String.class))).willReturn(
             createResponse);
 
         //when
         ResultActions result = mockMvc.perform(post("/markets")
+            .session(session)
             .content(objectMapper.writeValueAsString(createRequest))
             .contentType(MediaType.APPLICATION_JSON)
         );
@@ -125,7 +151,8 @@ class MarketControllerTest {
             .andExpect(jsonPath("$.name").exists())
             .andExpect(jsonPath("$.url").exists())
             .andExpect(jsonPath("$.sellerId").exists());
-        then(marketService).should().createMarket(refEq(createRequest));
+        then(marketService).should().createMarket(refEq(createRequest),
+            refEq((String) session.getAttribute(UserConstant.EMAIL)));
     }
 
     @Test
@@ -137,10 +164,11 @@ class MarketControllerTest {
         String marketName = RandomStringUtils.random(201, "가나다라마바사아자차카타파하");
         String url = RandomStringUtils.randomAlphabetic(101);
 
-        MarketDto.CreateRequest createMarketRequest = createMarketCreateRequest(sellerId, url, marketName);
+        MarketDto.CreateRequest createMarketRequest = createMarketCreateRequest(url, marketName);
 
         //when
         ResultActions result = mockMvc.perform(post("/markets")
+            .session(session)
             .content(objectMapper.writeValueAsString(createMarketRequest))
             .contentType(MediaType.APPLICATION_JSON)
         );
@@ -155,12 +183,14 @@ class MarketControllerTest {
     @ParameterizedTest
     @ValueSource(strings = {"한글입력", "include blank", "url!!"})
     @DisplayName("잘못된 형식의 URL로 마켓 생성 실패한다.")
-    public void givenInvalidUrl_whenCreatingMarket_then400BadRequestWithMessage(String invalidUrl) throws Exception {
+    public void givenInvalidUrl_whenCreatingMarket_then400BadRequestWithMessage(String invalidUrl)
+        throws Exception {
         //given
-        MarketDto.CreateRequest createRequest = createMarketCreateRequest("sellerId", invalidUrl, "마켓명");
+        MarketDto.CreateRequest createRequest = createMarketCreateRequest(invalidUrl, "마켓명");
 
         //when
         ResultActions result = mockMvc.perform(post("/markets")
+            .session(session)
             .content(objectMapper.writeValueAsString(createRequest))
             .contentType(MediaType.APPLICATION_JSON)
         );
@@ -172,9 +202,8 @@ class MarketControllerTest {
         then(marketService).shouldHaveNoInteractions();
     }
 
-    private MarketDto.CreateRequest createMarketCreateRequest(String sellerId, String url, String name) {
+    private MarketDto.CreateRequest createMarketCreateRequest(String url, String name) {
         return MarketDto.CreateRequest.builder()
-            .sellerId(sellerId)
             .name(name)
             .url(url)
             .build();
@@ -182,7 +211,7 @@ class MarketControllerTest {
 
     private CreateResponse createMarketCreateResponse(MarketDto.CreateRequest createRequest) {
         MarketDto.CreateResponse createResponse = MarketDto.CreateResponse.builder()
-            .market(createRequest.toEntity())
+            .market(createRequest.toEntity((String) session.getAttribute(UserConstant.EMAIL)))
             .build();
         createResponse.setId(1L);
         createResponse.setCreatedAt(LocalDateTime.now());

--- a/src/test/java/com/flab/modu/market/service/MarketServiceTest.java
+++ b/src/test/java/com/flab/modu/market/service/MarketServiceTest.java
@@ -32,11 +32,13 @@ class MarketServiceTest {
     @DisplayName("정상적으로 마켓생성에 성공한다.")
     public void givenTestData_whenCreatingMarket_thenSuccess() {
         // given
+        String sellerId = "sellerId";
         MarketDto.CreateRequest createRequest = createMarketDto();
-        given(marketRepository.save(any(Market.class))).willReturn(createRequest.toEntity());
+        given(marketRepository.save(any(Market.class))).willReturn(
+            createRequest.toEntity(sellerId));
 
         // when
-        marketService.createMarket(createRequest);
+        marketService.createMarket(createRequest, sellerId);
 
         // then
         then(marketRepository).should().existsByUrl(anyString());
@@ -47,12 +49,14 @@ class MarketServiceTest {
     @DisplayName("마켓주소 중복으로 마켓생성에 실패한다.")
     public void givenDuplicatedUrl_whenCreatingMarket_thenFailure() {
         // given
+        String sellerId = "sellerId";
         MarketDto.CreateRequest createRequest = createMarketDto();
         String existingUrl = "MarketUrl";
         given(marketRepository.existsByUrl(existingUrl)).willReturn(true);
 
         // when
-        assertThrows(DuplicatedUrlException.class, () -> marketService.createMarket(createRequest));
+        assertThrows(DuplicatedUrlException.class,
+            () -> marketService.createMarket(createRequest, sellerId));
 
         // then
         then(marketRepository).should().existsByUrl(existingUrl);
@@ -61,7 +65,6 @@ class MarketServiceTest {
 
     private CreateRequest createMarketDto() {
         return MarketDto.CreateRequest.builder()
-            .sellerId("sellerId")
             .url("MarketUrl")
             .name("마켓명")
             .build();


### PR DESCRIPTION
마켓 생성 기능에 로그인 기능을 연동하기위해 아래와 같은 작업을 진행하였다.
- Controller에서 @SessionAttribute로 session에 저장된 사용자 정보 가져오도록 수정하고, 더이상 파라메터로 넘어오지 않는 MarketDto.CreateRequest의 sellerId를 제거함
- 엔티티생성시 필요한 sellerId는 DTO->엔티티 변환할 때 넘겨주도록 수정
- 마켓 컨트롤러 테스트를 위해 MockMvc로 요청시 세션정보를 포함시키도록 수정하고, 변경된 서비스 메소드의 파라메터에 맞추어 Mocking하도록 수정함
- Spring Rest Docs 문서가 잘 만들어질 수 있도록 파라메터에 대한 변경 내용 적용함.

This close #14 