### PR TITLE
#22 - Market엔티티가 BaseTimeEntity를 상속받도록 수정

### DIFF
--- a/src/main/java/com/flab/modu/global/domain/BaseTimeEntity.java
+++ b/src/main/java/com/flab/modu/global/domain/BaseTimeEntity.java
@@ -4,11 +4,13 @@ import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.format.annotation.DateTimeFormat;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {

--- a/src/main/java/com/flab/modu/market/domain/Market.java
+++ b/src/main/java/com/flab/modu/market/domain/Market.java
@@ -1,5 +1,6 @@
 package com.flab.modu.market.domain;
 
+import com.flab.modu.global.domain.BaseTimeEntity;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
@@ -23,9 +24,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Market {
+public class Market extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,14 +43,6 @@ public class Market {
 
     @Column(nullable = false, length = 100)
     private String url;
-
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;
 
     @Builder
     public Market(String sellerId, String name, String url, MarketStatus status) {


### PR DESCRIPTION
User엔티티와 코드를 통일시키기 위해서 BaseTimeEntity를 상속받도록 수정하고, MarketDto에서 Date에 대한 Getter메소드를 사용하기때문에 Getter메소드를 쓸 수 있도록 @Getter애노테이션을 붙임

This closes #22 